### PR TITLE
Small speed tweak for dictionary lookups used to find already cloned …

### DIFF
--- a/src/CloneExtensions/Helpers.cs
+++ b/src/CloneExtensions/Helpers.cs
@@ -1,46 +1,46 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Linq;
 
 namespace CloneExtensions
 {
-	static internal class Helpers
-	{
-		public static Expression GetCloningFlagsExpression(CloningFlags flags, ParameterExpression parameter)
-		{
-			var flagExpression = Expression.Convert(Expression.Constant(flags, typeof(CloningFlags)), typeof(byte));
+    static internal class Helpers
+    {
+        public static Expression GetCloningFlagsExpression(CloningFlags flags, ParameterExpression parameter)
+        {
+            var flagExpression = Expression.Convert(Expression.Constant(flags, typeof(CloningFlags)), typeof(byte));
 
-			return Expression.Equal(
-				Expression.And(
-					Expression.Convert(parameter, typeof(byte)),
-					flagExpression
-				),
-				flagExpression
-			);
-		}
+            return Expression.Equal(
+                Expression.And(
+                    Expression.Convert(parameter, typeof(byte)),
+                    flagExpression
+                ),
+                flagExpression
+            );
+        }
 
-		public static Expression GetCloneMethodCall(Type type, Expression source, Expression flags, Expression initializers, Expression clonedObjects)
-		{
-			return Expression.Call(typeof(CloneFactory), "GetClone", new[] { type }, source, flags, initializers, clonedObjects);
-		}
+        public static Expression GetCloneMethodCall(Type type, Expression source, Expression flags, Expression initializers, Expression clonedObjects)
+        {
+            return Expression.Call(typeof(CloneFactory), "GetClone", new[] { type }, source, flags, initializers, clonedObjects);
+        }
 
-		public static Expression GetThrowInvalidOperationExceptionExpression(Type type)
-		{
-			var message = string.Format("You have to provide initialization expression for {0}.", type.FullName);
+        public static Expression GetThrowInvalidOperationExceptionExpression(Type type)
+        {
+            var message = string.Format("You have to provide initialization expression for {0}.", type.FullName);
 
-			return Expression.Throw(
-				Expression.New(
-					typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
-					Expression.Constant(message, typeof(string))
-				)
-			);
-		}
+            return Expression.Throw(
+                Expression.New(
+                    typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
+                    Expression.Constant(message, typeof(string))
+                )
+            );
+        }
 
-		public static T GetFromClonedObjects<T>(Dictionary<object, object> clonedObjects, T source)
-		{
-			object returnValue = null;
-			clonedObjects.TryGetValue(source, out returnValue);
-			return returnValue != null ? (T)returnValue : default(T);
-		}
-	}
+        public static T GetFromClonedObjects<T>(Dictionary<object, object> clonedObjects, T source)
+        {
+            var key = clonedObjects.Keys.FirstOrDefault(k => ReferenceEquals(k, source));
+            return key != null ? (T)clonedObjects[key] : default(T);
+        }
+    }
 }

--- a/src/CloneExtensions/Helpers.cs
+++ b/src/CloneExtensions/Helpers.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Linq;
 
 namespace CloneExtensions
 {
@@ -39,8 +38,9 @@ namespace CloneExtensions
 
         public static T GetFromClonedObjects<T>(Dictionary<object, object> clonedObjects, T source)
         {
-            var key = clonedObjects.Keys.FirstOrDefault(k => ReferenceEquals(k, source));
-            return key != null ? (T)clonedObjects[key] : default(T);
+            object returnValue;
+            clonedObjects.TryGetValue(source, out returnValue);
+            return returnValue != null ? (T)returnValue : default(T);
         }
     }
 }

--- a/src/CloneExtensions/Helpers.cs
+++ b/src/CloneExtensions/Helpers.cs
@@ -1,46 +1,46 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Linq;
 
 namespace CloneExtensions
 {
-    static internal class Helpers
-    {
-        public static Expression GetCloningFlagsExpression(CloningFlags flags, ParameterExpression parameter)
-        {
-            var flagExpression = Expression.Convert(Expression.Constant(flags, typeof(CloningFlags)), typeof(byte));
+	static internal class Helpers
+	{
+		public static Expression GetCloningFlagsExpression(CloningFlags flags, ParameterExpression parameter)
+		{
+			var flagExpression = Expression.Convert(Expression.Constant(flags, typeof(CloningFlags)), typeof(byte));
 
-            return Expression.Equal(
-                Expression.And(
-                    Expression.Convert(parameter, typeof(byte)),
-                    flagExpression
-                ),
-                flagExpression
-            );
-        }
+			return Expression.Equal(
+				Expression.And(
+					Expression.Convert(parameter, typeof(byte)),
+					flagExpression
+				),
+				flagExpression
+			);
+		}
 
-        public static Expression GetCloneMethodCall(Type type, Expression source, Expression flags, Expression initializers, Expression clonedObjects)
-        {
-            return Expression.Call(typeof(CloneFactory), "GetClone", new[] { type }, source, flags, initializers, clonedObjects);
-        }
+		public static Expression GetCloneMethodCall(Type type, Expression source, Expression flags, Expression initializers, Expression clonedObjects)
+		{
+			return Expression.Call(typeof(CloneFactory), "GetClone", new[] { type }, source, flags, initializers, clonedObjects);
+		}
 
-        public static Expression GetThrowInvalidOperationExceptionExpression(Type type)
-        {
-            var message = string.Format("You have to provide initialization expression for {0}.", type.FullName);
+		public static Expression GetThrowInvalidOperationExceptionExpression(Type type)
+		{
+			var message = string.Format("You have to provide initialization expression for {0}.", type.FullName);
 
-            return Expression.Throw(
-                Expression.New(
-                    typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
-                    Expression.Constant(message, typeof(string))
-                )
-            );
-        }
+			return Expression.Throw(
+				Expression.New(
+					typeof(InvalidOperationException).GetConstructor(new[] { typeof(string) }),
+					Expression.Constant(message, typeof(string))
+				)
+			);
+		}
 
-        public static T GetFromClonedObjects<T>(Dictionary<object, object> clonedObjects, T source)
-        {
-            var key = clonedObjects.Keys.FirstOrDefault(k => ReferenceEquals(k, source));
-            return key != null ? (T)clonedObjects[key] : default(T);
-        }
-    }
+		public static T GetFromClonedObjects<T>(Dictionary<object, object> clonedObjects, T source)
+		{
+			object returnValue = null;
+			clonedObjects.TryGetValue(source, out returnValue);
+			return returnValue != null ? (T)returnValue : default(T);
+		}
+	}
 }


### PR DESCRIPTION
…objects and deal with circular references.

A dictionary<object, object> lookup uses reference equality, for
reference types only, by default.  The previous method checks a list of
objects to find the key (O(n)) which forgoes the speed of a hash (O(1))
and is much slower.  There are some caveats that I am aware of:

1) Value types, for dictionary lookups, do not use reference equality
for finding keys ... they use a different method that calculates a hash
code for the object.  This allows two very different value type objects
to have the exact same key leading to a value type that should be cloned
to not be.  Because of this, no value types should ever be added to the
dictionary ... only reference types.

2) The method used to look up keys in the dictionary<object, object>
uses reference equality by default, but it could be changed by the user
inadvertantly if the EqualityComparer for the Dictionary was ever
changed from the default.

If point 1 or 2 are ever false, the suggested change should not be used.

I did not create a unit test here to display the differences in speed
but I did do so in another project which compare the unmodified code
with a rewrite that is optimized.  The unmodified code performed 27
clones per second, the modified code perform 1724 clones per second ...
about 1/63 of the original time.