### PR TITLE
Add ArrayPrimitiveTypeExpressionFactory.

### DIFF
--- a/src/CloneExtensions/ExpressionFactories/ArrayExpressionFactory.cs
+++ b/src/CloneExtensions/ExpressionFactories/ArrayExpressionFactory.cs
@@ -9,7 +9,7 @@ namespace CloneExtensions.ExpressionFactories
     {
         private Type _itemType;
         private Expression _arrayLength;
-        private Expression _newArray;
+        protected Expression _newArray;
 
         public ArrayExpressionFactory(ParameterExpression source, Expression target, ParameterExpression flags, ParameterExpression initializers, ParameterExpression clonedObjects)
             : base(source, target, flags, initializers, clonedObjects)

--- a/src/CloneExtensions/ExpressionFactories/ArrayPrimitiveTypeExpressionFactory.cs
+++ b/src/CloneExtensions/ExpressionFactories/ArrayPrimitiveTypeExpressionFactory.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace CloneExtensions.ExpressionFactories
+{
+    class ArrayPrimitiveTypeExpressionFactory<T> : ArrayExpressionFactory<T>
+    {
+        private static MethodInfo _copyTo = typeof(Array).GetRuntimeMethod(
+            "CopyTo",
+            new Type[2] { typeof(Array), typeof(int) });
+
+        public ArrayPrimitiveTypeExpressionFactory(
+            ParameterExpression source,
+            Expression target,
+            ParameterExpression flags,
+            ParameterExpression initializers,
+            ParameterExpression clonedObjects)
+            : base(source, target, flags, initializers, clonedObjects)
+        {
+        }
+
+        protected override Expression GetCloneExpression(Func<Type, Expression, Expression> getItemCloneExpression)
+        {
+            var assign = Expression.Assign(
+                Target,
+                _newArray);
+
+            var copy = Expression.Call(
+                Source,
+                _copyTo,
+                Target,
+                Expression.Constant(0));
+
+            return Expression.Block(
+                assign,
+                GetAddToClonedObjectsExpression(),
+                copy);
+        }
+    }
+}

--- a/src/CloneExtensions/ExpressionFactory.cs
+++ b/src/CloneExtensions/ExpressionFactory.cs
@@ -1,6 +1,7 @@
 ﻿using CloneExtensions.ExpressionFactories;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace CloneExtensions
@@ -108,7 +109,20 @@ namespace CloneExtensions
             }
             else if (_type.IsArray)
             {
-                return new ArrayExpressionFactory<T>(source, target, flags, initializers, clonedObjects);
+                var itemType = _type
+                    .GetInterfaces()
+                    .First(x => x.IsGenericType() && x.GetGenericTypeDefinition() == typeof(ICollection<>))
+                    .GetGenericArguments()
+                    .First();
+
+                if (_type.IsPrimitiveOrKnownImmutable() || typeof(Delegate).IsAssignableFrom(_type))
+                {
+                    return new ArrayPrimitiveTypeExpressionFactory<T>(source, target, flags, initializers, clonedObjects);
+                }
+                else
+                {
+                    return new ArrayExpressionFactory<T>(source, target, flags, initializers, clonedObjects);
+                }
             }
             else if (_type.IsGenericType() &&
                 (_type.GetGenericTypeDefinition() == typeof(Tuple<>)


### PR DESCRIPTION
When cloning Primitives all that needs to be done is copy the source
array to the target array.  Instead of calling the
PrimitiveTypeExpressionFactory call for every element you can use the
static Array.Copy method to assist.

Depending upon the primitive type, the performance gain is different.
In the tests I have, which are coded against 4.6.1, will have a
performance gain of any where from about 98% to almost 225%.  Byte
Array, for whatever reason, has a performance gain of about 6800% ... I
have no idea why byte arrays are so much different.

Int Arrays go from about 2,386,634 ops per sec to 4,727,659 (98% increase)
String arrays go from about 1,926,782 ops per sec to 5,730,086 (197% increase)
TimeSpan arrays go from about 1,988,071 ops per sec to 4,650,697 (133% increase)
DateTime arrays go from about 1,930,501 ops per sec to 4,210,105 (118% increase)
Delegate arrays go from about 1,659,751 ops per sec to 5,404,864 (225% increase)
Byte arrays go from about 58,083 ops per sec to 4,053,648 (6879% increase)

I would like supply a unit test to easily display the difference in
performance in the master project, but given the interface, it is not
exactly straight forward.  I generated the numbers above from running
the changes suggested from a local release build in my current test
setup.