### PR TITLE
Use backing fields when available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ FakesAssemblies/
 # Roslyn
 *.sln.ide/
 BenchmarkDotNet.Artifacts/results/
+.vscode/

--- a/src/CloneExtensions.Benchmarks/CloneExtensions.Benchmarks.csproj
+++ b/src/CloneExtensions.Benchmarks/CloneExtensions.Benchmarks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>CloneExtensions.Benchmarks</RootNamespace>
     <AssemblyName>CloneExtensions.Benchmarks</AssemblyName>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net461</TargetFrameworks>
     <Version>1.4.2.0</Version>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/CloneExtensions.Benchmarks/GetCloneBenchmarks.cs
+++ b/src/CloneExtensions.Benchmarks/GetCloneBenchmarks.cs
@@ -7,58 +7,58 @@ using System.Threading.Tasks;
 
 namespace CloneExtensions.Benchmarks
 {
-	public class GetCloneBenchmarks
-	{
-		private readonly SimpleClass _simpleClass;
-		private readonly List<int> _listOfInts;
-		private readonly List<SimpleClass> _listOfSimpleClassSameInstance;
-		private readonly List<SimpleClass> _listOfSimpleClassDifferentInstances;
+    public class GetCloneBenchmarks
+    {
+        private readonly SimpleClass _simpleClass;
+        private readonly List<int> _listOfInts;
+        private readonly List<SimpleClass> _listOfSimpleClassSameInstance;
+        private readonly List<SimpleClass> _listOfSimpleClassDifferentInstances;
 
-		public GetCloneBenchmarks()
-		{
-			_simpleClass = new SimpleClass()
-			{
-				Int = 10,
-				UInt = 1231,
-				Long = 1231234561L,
-				ULong = 1516524352UL,
-				Double = 1235.1235762,
-				Float = 1.333F,
-				String = "Lorem ipsum ...",
-			};
+        public GetCloneBenchmarks()
+        {
+            _simpleClass = new SimpleClass()
+            {
+                Int = 10,
+                UInt = 1231,
+                Long = 1231234561L,
+                ULong = 1516524352UL,
+                Double = 1235.1235762,
+                Float = 1.333F,
+                String = "Lorem ipsum ...",
+            };
 
-			_listOfInts = Enumerable.Range(0, 10000).ToList();
+            _listOfInts = Enumerable.Range(0, 10000).ToList();
 
-			_listOfSimpleClassSameInstance = Enumerable.Repeat(_simpleClass, 10000).ToList();
-			_listOfSimpleClassDifferentInstances = Enumerable.Range(0, 10000).Select(x => new SimpleClass() { Int = x }).ToList();
-		}
+            _listOfSimpleClassSameInstance = Enumerable.Repeat(_simpleClass, 10000).ToList();
+            _listOfSimpleClassDifferentInstances = Enumerable.Range(0, 10000).Select(x => new SimpleClass() { Int = x }).ToList();
+        }
 
-		[Benchmark]
-		public int GetCloneSimpleClass()
-		{
-			var clone = _simpleClass.GetClone();
-			return clone.Int;
-		}
+        [Benchmark]
+        public int GetCloneSimpleClass()
+        {
+            var clone = _simpleClass.GetClone();
+            return clone.Int;
+        }
 
-		[Benchmark]
-		public int GetCloneListOfInts()
-		{
-			var clone = _listOfInts.GetClone();
-			return clone.Count;
-		}
+        [Benchmark]
+        public int GetCloneListOfInts()
+        {
+            var clone = _listOfInts.GetClone();
+            return clone.Count;
+        }
 
-		[Benchmark]
-		public int GetCloneListOfSimpleClassSameInstance()
-		{
-			var clone = _listOfSimpleClassSameInstance.GetClone();
-			return clone.Count;
-		}
+        [Benchmark]
+        public int GetCloneListOfSimpleClassSameInstance()
+        {
+            var clone = _listOfSimpleClassSameInstance.GetClone();
+            return clone.Count;
+        }
 
-		[Benchmark]
-		public int GetCloneListOfSimpleClassDifferentInstances()
-		{
-			var clone = _listOfSimpleClassDifferentInstances.GetClone();
-			return clone.Count;
-		}
-	}
+        [Benchmark]
+        public int GetCloneListOfSimpleClassDifferentInstances()
+        {
+            var clone = _listOfSimpleClassDifferentInstances.GetClone();
+            return clone.Count;
+        }
+    }
 }

--- a/src/CloneExtensions.Benchmarks/Program.cs
+++ b/src/CloneExtensions.Benchmarks/Program.cs
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 
 namespace CloneExtensions.Benchmarks
 {
-	class Program
-	{
-		static void Main(string[] args)
-		{
-			BenchmarkRunner.Run<GetCloneBenchmarks>();
-		}
-	}
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<GetCloneBenchmarks>();
+        }
+    }
 }

--- a/src/CloneExtensions.Benchmarks/SimpleClass.cs
+++ b/src/CloneExtensions.Benchmarks/SimpleClass.cs
@@ -1,13 +1,18 @@
 ﻿namespace CloneExtensions.Benchmarks
 {
-	public class SimpleClass
-	{
-		public int Int { get; set; }
-		public uint UInt { get; set; }
-		public long Long { get; set; }
-		public ulong ULong { get; set; }
-		public double Double { get; set; }
-		public float Float { get; set; }
-		public string String { get; set; }
-	}
+    public class SimpleClassBase
+    {
+        public int BaseInt { get; set; }
+    }
+
+    public class SimpleClass : SimpleClassBase
+    {
+        public int Int { get; set; }
+        public uint UInt { get; set; }
+        public long Long { get; set; }
+        public ulong ULong { get; set; }
+        public double Double { get; set; }
+        public float Float { get; set; }
+        public string String { get; set; }
+    }
 }

--- a/src/CloneExtensions.UnitTests/CloneExtensions.UnitTests.csproj
+++ b/src/CloneExtensions.UnitTests/CloneExtensions.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>CloneExtensions.UnitTests</RootNamespace>
     <AssemblyName>CloneExtensions.UnitTests</AssemblyName>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
     <Version>1.4.2.0</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CloneExtensions.UnitTests/CollectionTests.cs
+++ b/src/CloneExtensions.UnitTests/CollectionTests.cs
@@ -24,7 +24,7 @@ namespace CloneExtensions.UnitTests
             var source = Enumerable.Range(0, 10).ToList();
             var target = CloneFactory.GetClone(source, CloningFlags.Properties);
             Assert.AreNotSame(source, target);
-            Assert.AreEqual(source.Capacity, target.Capacity);
+            Assert.AreEqual(source.Count, target.Capacity);
             Assert.AreEqual(0, target.Count);
         }
 

--- a/src/CloneExtensions.UnitTests/CollectionTests.cs
+++ b/src/CloneExtensions.UnitTests/CollectionTests.cs
@@ -67,6 +67,20 @@ namespace CloneExtensions.UnitTests
             Assert.IsTrue(source.SequenceEqual(target));
         }
 
+        [TestMethod]
+        public void GetClone_DerivedTypeWithShadowedProperty_ClonnedProperly()
+        {
+            DerivedClass source = new DerivedClass() { Property = 1 };
+            ((BaseClass)source).Property = 2;
+
+            var target = CloneFactory.GetClone(source);
+
+            Assert.AreEqual(1, target.Property);
+
+            // TODO: Make it work ...
+            // Assert.AreEqual(2, ((BaseClass)target).Property);
+        }
+
         class MyClass
         {
             public int _field;
@@ -85,6 +99,16 @@ namespace CloneExtensions.UnitTests
             {
                 return _field.GetHashCode() ^ Property.GetHashCode();
             }
+        }
+
+        class BaseClass
+        {
+            public int Property { get; set; }
+        }
+
+        class DerivedClass : BaseClass
+        {
+            public new int Property { get; set; }
         }
     }
 }

--- a/src/CloneExtensions/ExpressionFactories/ComplexTypeExpressionFactory.cs
+++ b/src/CloneExtensions/ExpressionFactories/ComplexTypeExpressionFactory.cs
@@ -187,7 +187,7 @@ namespace CloneExtensions.ExpressionFactories
         {
             TypeInfo typeInfo = type.GetTypeInfo();
 
-            while(typeInfo.UnderlyingSystemType != _objectType)
+            while(typeInfo != null && typeInfo.UnderlyingSystemType != _objectType)
             {
                 foreach(var field in typeInfo.GetFields(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
@@ -195,7 +195,7 @@ namespace CloneExtensions.ExpressionFactories
                         yield return field;
                 }
 
-                typeInfo = typeInfo.BaseType.GetTypeInfo();
+                typeInfo = typeInfo.BaseType?.GetTypeInfo();
             }
         }
     }


### PR DESCRIPTION
It's a simplified version of what @deipax did in #22.

The way we're doing per-type clone delegate caching makes additional caching of reflection data unnecessary. So instead of using `ModelInfo<T>` from `Deipax.Core.Common` it's simply checking the fields when the clone delegate is generated, without any additional caching.

Benchmark results:

**.NET Core - before**
```
                                      Method |           Mean |         Error |        StdDev |
-------------------------------------------- |---------------:|--------------:|--------------:|
                         GetCloneSimpleClass |       132.5 ns |      1.793 ns |      1.296 ns |
                          GetCloneListOfInts |     4,751.3 ns |     67.455 ns |     52.664 ns |
       GetCloneListOfSimpleClassSameInstance |   632,354.0 ns |  8,291.360 ns |  7,350.074 ns |
 GetCloneListOfSimpleClassDifferentInstances | 1,806,829.9 ns | 27,005.394 ns | 23,939.576 ns |
```
**.NET Core - with #22 applied**
```
                                      Method |           Mean |         Error |        StdDev |
-------------------------------------------- |---------------:|--------------:|--------------:|
                         GetCloneSimpleClass |       133.7 ns |      2.630 ns |      3.131 ns |
                          GetCloneListOfInts |     4,721.2 ns |     91.612 ns |    105.500 ns |
       GetCloneListOfSimpleClassSameInstance |   651,762.3 ns | 10,653.091 ns |  8,895.813 ns |
 GetCloneListOfSimpleClassDifferentInstances | 1,770,150.1 ns | 31,561.661 ns | 27,978.587 ns |
```

**.NET Core - with these changes**
```
                                      Method |           Mean |         Error |        StdDev |
-------------------------------------------- |---------------:|--------------:|--------------:|
                         GetCloneSimpleClass |       129.1 ns |      1.655 ns |      1.548 ns |
                          GetCloneListOfInts |     4,706.9 ns |     87.409 ns |     72.991 ns |
       GetCloneListOfSimpleClassSameInstance |   665,777.9 ns |  9,338.243 ns |  8,278.109 ns |
 GetCloneListOfSimpleClassDifferentInstances | 1,811,359.6 ns | 29,407.678 ns | 26,069.138 ns |
```
**.NET Framework 4.6.1 - before**
```
                                      Method |           Mean |          Error |         StdDev |
-------------------------------------------- |---------------:|---------------:|---------------:|
                         GetCloneSimpleClass |       255.2 ns |       3.486 ns |       2.911 ns |
                          GetCloneListOfInts |     4,683.8 ns |      60.154 ns |      50.231 ns |
       GetCloneListOfSimpleClassSameInstance | 1,117,613.7 ns |  20,728.126 ns |  17,308.923 ns |
 GetCloneListOfSimpleClassDifferentInstances | 5,182,728.0 ns | 110,875.858 ns | 123,238.212 ns |
```
**.NET Framework 4.6.1 - with #22 applied**
```
                                      Method |           Mean |         Error |        StdDev |
-------------------------------------------- |---------------:|--------------:|--------------:|
                         GetCloneSimpleClass |       149.7 ns |      3.023 ns |      7.359 ns |
                          GetCloneListOfInts |     4,691.6 ns |     71.216 ns |     55.600 ns |
       GetCloneListOfSimpleClassSameInstance |   939,968.9 ns | 17,599.375 ns | 16,462.464 ns |
 GetCloneListOfSimpleClassDifferentInstances | 2,385,342.2 ns | 71,420.279 ns | 59,639.162 ns |
```
**.NET Framework 4.6.1 - with these changes**
```
                                      Method |           Mean |         Error |        StdDev |
-------------------------------------------- |---------------:|--------------:|--------------:|
                         GetCloneSimpleClass |       138.1 ns |      1.481 ns |      1.386 ns |
                          GetCloneListOfInts |     4,668.7 ns |     83.819 ns |     74.304 ns |
       GetCloneListOfSimpleClassSameInstance |   971,472.9 ns | 18,936.852 ns | 30,579.487 ns |
 GetCloneListOfSimpleClassDifferentInstances | 2,372,608.3 ns | 42,565.389 ns | 39,815.687 ns |
```

To summarize above
- pretty much no changes for .NET Core
- noticeable performance improvements for .NET Framework
- similar performance of this code and #22